### PR TITLE
Added host variable in targets, documented in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ As a consequence, in case you want to use the same account for all github projec
 [github.com*]
 target=dev/github
 ```
+In order to allow the usage of the host to address a pass entry, there is one variable substitution that takes place: `${host}` in the `target` is replaced by the host you're querying. This is especially helpful for wildcard matches:
+```ini
+[*]
+target=git-logins/${host}
+```
+The above configuration directive will lead to any host that didn't match any previous section in the ini file to being looked for under the `git-logins` directory in your password store.
 
 ## Passwordstore Layout
 

--- a/pass-git-helper
+++ b/pass-git-helper
@@ -109,7 +109,7 @@ def get_password(request, mapping):
             LOGGER.debug('Section "%s" matches requested host "%s"',
                          section, host)
             # TODO handle exceptions
-            pass_target = mapping.get(section, 'target')
+            pass_target = mapping.get(section, 'target').replace("${host}", host)
             skip_password_chars = mapping.getint(
                 section, 'skip_password', fallback=0)
             skip_username_chars = mapping.getint(


### PR DESCRIPTION
Now, you can use `${host}` in your `target=`, enabling wildcard matches
in the ini, so that one ini entry can match mutliple hosts with
different passwords successfully.