### PR TITLE
Add `file_is_username` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The above configuration directive will lead to any host that did not match any p
 As usual with [pass], this helper assumes that the password is contained in the first line of the passwordstore entry.
 Additionally, if a second line is present, this line is interpreted as the username and also returned back to the git process invoking this helper.
 In case you use markers at the start of lines to identify what is contained in this line, e.g. like `Username: fooo`, the options `skip_username` and `skip_password` can be defined in each mapping to skip the given amount of characters from the beginning of the respective line.
+Another possible layout is for the passwordstore entry to be the username itself. You can then set `file_is_username` to `True` or `False`.
 Additionally, global defaults can be configured via the `DEFAULT` section:
 ```ini
 [DEFAULT]
@@ -96,6 +97,11 @@ skip_username=10
 target=special/somedomain
 # somehow this entry does not have a prefix for the username
 skip_username=0
+
+[otherdomain]
+target=otherdomain/johndoe
+# username is johndoe
+file_is_username=True
 ```
 
 ## Command Line Options

--- a/pass-git-helper
+++ b/pass-git-helper
@@ -114,15 +114,20 @@ def get_password(request, mapping):
                 section, 'skip_password', fallback=0)
             skip_username_chars = mapping.getint(
                 section, 'skip_username', fallback=0)
+            file_is_username = mapping.getboolean(
+                    section, 'file_is_username', fallback=False)
             LOGGER.debug('Requesting entry "%s" from pass', pass_target)
             output = subprocess.check_output(['pass', 'show', pass_target])
             lines = output.splitlines()
             if len(lines) >= 1:
                 print('password={}'.format(
                     decode_skip(lines[0], skip_password_chars)))
-            if 'username' not in request and len(lines) >= 2:
-                print('username={}'.format(
-                    decode_skip(lines[1], skip_username_chars)))
+            if 'username' not in request and (len(lines) >= 2 or file_is_username):
+                if file_is_username:
+                    username = os.path.basename(pass_target)
+                else:
+                    username = decode_skip(lines[1], skip_username_chars)
+                print('username={}'.format(username))
             return
 
     LOGGER.warning('No mapping matched')


### PR DESCRIPTION
Another of the possible layouts for the passwordstore is to have a domain/username structure, with the content being only the password. This makes it easier to handle, for example, expiring passwords, where I have to `pass generate` every 30 days, overwriting the username in the process.

**This PR comes with a big caveat**: I have NOT been able to verify the new option behaves as expected when in the DEFAULT section mentioned in the README. We probably should check that before merging.