### PR TITLE
Add a ${username} variable for use in targets

### DIFF
--- a/passgithelper.py
+++ b/passgithelper.py
@@ -354,6 +354,9 @@ def get_password(request, mapping) -> None:
             # TODO handle exceptions
             pass_target = mapping.get(section, 'target').replace(
                 "${host}", request['host'])
+            if 'username' in request:
+                pass_target = pass_target.replace(
+                    "${username}", request['username'])
 
             password_extractor = SpecificLineExtractor(
                 0, 0, option_suffix='_password')

--- a/test_data/wildcard/git-pass-mapping.ini
+++ b/test_data/wildcard/git-pass-mapping.ini
@@ -1,2 +1,2 @@
 [*]
-target=dev/${host}
+target=dev/${host}/${username}

--- a/test_passgithelper.py
+++ b/test_passgithelper.py
@@ -208,6 +208,7 @@ path=subpath/bar.git'''))
         monkeypatch.setattr('sys.stdin', io.StringIO('''
 protocol=https
 host=wildcard.com
+username=wildcard
 path=subpath/bar.git'''))
 
         subprocess_mock = mocker.patch('subprocess.check_output')
@@ -217,7 +218,7 @@ path=subpath/bar.git'''))
 
         subprocess_mock.assert_called_once()
         subprocess_mock.assert_called_with(
-            ['pass', 'show', 'dev/wildcard.com'])
+            ['pass', 'show', 'dev/wildcard.com/wildcard'])
 
         out, _ = capsys.readouterr()
         assert out == 'password=narf-wildcard\n'


### PR DESCRIPTION
In git-send-email, it requests a credential with a host and a username.
Normally this would be fine, but it can cause issues if you have
multiple email accounts on a single host (ex. multiple gmail accounts;
pass-git-helper sees them all as host=smtp.gmail.com:587). Having a
${username} (the variable matching the username requested) fixes this.