### PR TITLE
Use detected system encoding instead of UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ For instance, if a regular [pass] call would be `pass show dev/github.com/langui
 
 No configuration options.
 
+### File Encoding
+
+By default, passwordstore entries are assumed to use UTF-8 encoding.
+If all or some of your entries use a different encoding, use the `encoding` key (for instance, in the `DEFAULT` section) to specify the used encoding.
+
 ## Command Line Options
 
 `-l` can be given as an option to the script to produce logging output on stderr.

--- a/passgithelper.py
+++ b/passgithelper.py
@@ -371,7 +371,7 @@ def get_password(request, mapping) -> None:
 
             LOGGER.debug('Requesting entry "%s" from pass', pass_target)
             output = subprocess.check_output(["pass", "show", pass_target]).decode(
-                "utf-8"
+                mapping[section].get("encoding", "UTF-8")
             )
             lines = output.splitlines()
 

--- a/test_data/with-encoding/git-pass-mapping.ini
+++ b/test_data/with-encoding/git-pass-mapping.ini
@@ -1,0 +1,5 @@
+[DEFAULT]
+encoding=LATIN1
+
+[mytest.com]
+target=dev/mytest


### PR DESCRIPTION
Instead of always assuming an UTF-8 encoding for for pass entries, use the encoding the system is likely using.

Will fix #27