### PR TITLE
ci: pin to working linting dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,9 @@ deps =
     flake8~=3.7.0
     dlint~=0.10.0
     flake8-annotations~=2.3.0
-    flake8-bandit~=2.1.0
-    flake8-black~=0.2.1
+    flake8-bandit~=2.1.2
+    bandit==1.7.2
+    flake8-black~=0.3.2
     flake8-bugbear~=20.1.4
     flake8-builtins~=1.5.3
     flake8-cognitive-complexity~=0.1.0
@@ -59,7 +60,7 @@ deps =
     flake8-variables-names~=0.0.3
     pep8-naming~=0.11.1
     mypy==0.790
-    black==20.8b0
+    black==22.1.0
 commands =
     {envbindir}/python -V
     {envbindir}/flake8 {posargs}


### PR DESCRIPTION
Some patch version upgrades have broken the linting setup. Pin some
things to working version.