### PR TITLE
Fix typo in help message

### DIFF
--- a/passgithelper.py
+++ b/passgithelper.py
@@ -68,7 +68,7 @@ def parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         "action",
         type=str,
         metavar="ACTION",
-        help="Action to preform as specified in the git credential API",
+        help="Action to perform as specified in the git credential API",
     )
 
     return parser.parse_args(argv)


### PR DESCRIPTION
I noticed this while tinkering with my install of the tool.

It's a quick guess at the correct fix done in the web editor - I think it's plausible but I haven't actually tested it.