### PR TITLE
test: update Python versions to modern ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Clone repo

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,test-py{37,38,39,310}, check, coverage
+envlist = coverage-clean,test-py{39,310,311}, check, coverage
 
 [testenv]
 extras = test
@@ -18,7 +18,7 @@ commands = coverage erase
 depends =
 
 [testenv:coverage]
-depends = test-py{37,38,39,310}
+depends = test-py{39,310,311}
 deps =
     coverage
 skip_install = true
@@ -40,7 +40,6 @@ commands =
 
 [gh-actions]
 python =
-    3.7: py37, coverage
-    3.8: py38, coverage
     3.9: py39, coverage
     3.10: py310, coverage
+    3.11: py311, coverage


### PR DESCRIPTION
Only test on what is still being used in Debian stable or Ubuntu LTS and include 3.11 now.