### PR TITLE
fix: improve error message for unknown username extractor

### DIFF
--- a/passgithelper.py
+++ b/passgithelper.py
@@ -388,9 +388,15 @@ def get_password(
 
     password_extractor = SpecificLineExtractor(0, 0, option_suffix="_password")
     password_extractor.configure(section)
-    username_extractor = _username_extractors[
-        section.get("username_extractor", fallback=_line_extractor_name)
-    ]
+
+    username_extractor_name = section.get(
+        "username_extractor", fallback=_line_extractor_name
+    )
+    username_extractor = _username_extractors.get(username_extractor_name)
+    if username_extractor is None:
+        raise ValueError(
+            f"A username_extractor of type '{username_extractor_name}' does not exist"
+        )
     username_extractor.configure(section)
 
     environment = compute_pass_environment(section)

--- a/test_passgithelper.py
+++ b/test_passgithelper.py
@@ -373,9 +373,11 @@ host=mytest.com""",
         indirect=True,
     )
     @pytest.mark.usefixtures("helper_config")
-    def test_select_unknown_extractor(self) -> None:
+    def test_select_unknown_extractor(self, capsys: Any) -> None:
         with pytest.raises(SystemExit):
             passgithelper.main(["get"])
+        _, err = capsys.readouterr()
+        assert "username_extractor of type 'doesntexist' does not exist" in err
 
     @pytest.mark.parametrize(
         "helper_config",


### PR DESCRIPTION
While adding tests for #372, I caused `test_select_unknown_extractor` to fail and had a hard time understanding why. This commit improves the error message for cases where the the configured `username_extractor` does not match an existing extractor.