### PR TITLE
switch from setup.py to setup.cfg

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,12 +18,12 @@
       {
         "replacements": [
           {
-            "files": ["setup.py"],
-            "from": "version=\".*\"",
-            "to": "version=\"${nextRelease.version}\"",
+            "files": ["passgithelper.py"],
+            "from": "__version__ = \".*\"",
+            "to": "__version__ = \"${nextRelease.version}\"",
             "results": [
               {
-                "file": "setup.py",
+                "file": "passgithelper.py",
                 "hasChanged": true,
                 "numMatches": 1,
                 "numReplacements": 1
@@ -37,7 +37,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["setup.py"]
+        "assets": ["passgithelper.py"]
      }
     ],
     "@semantic-release/github"

--- a/passgithelper.py
+++ b/passgithelper.py
@@ -22,6 +22,8 @@ from typing import Dict, IO, Mapping, Optional, Pattern, Sequence, Text
 import xdg.BaseDirectory
 
 
+__version__ = "3.1.0"
+
 LOGGER = logging.getLogger()
 CONFIG_FILE_NAME = "git-pass-mapping.ini"
 DEFAULT_CONFIG_FILE = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,37 @@
+[metadata]
+name = pass-git-helper
+version = attr: passgithelper.__version__
+author  =  Johannes Wienke
+author_email = languitar@semipol.de
+description = A git credential helper interfacing with pass, the standard Unix password manager
+license = LGPLv3+
+keywords =
+    git
+    passwords
+    pass
+    credentials
+    password store
+classifiers =
+    Programming Language :: Python :: 3
+    Topic :: Utilities
+    License :: OSI Approved ::
+    GNU Lesser General Public License v3 or later (LGPLv3+)
+project_urls =
+    home_page = https://github.com/languitar/pass-git-helper
+
+[options]
+install_requires =
+    pyxdg
+py_modules =
+    passgithelper
+
+[options.extras_require]
+test = pytest; pytest-coverage; pytest-mock
+
+[options.entry_points]
+console_scripts =
+    pass-git-helper = passgithelper:main
+
 [tool:pytest]
 log_level = DEBUG
 addopts =

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,3 @@
 from setuptools import setup
 
-
-setup(
-    name="pass-git-helper",
-    version="3.1.0",
-    install_requires=["pyxdg"],
-    extras_require={"test": ["pytest", "pytest-coverage", "pytest-mock"]},
-    py_modules=["passgithelper"],
-    entry_points={"console_scripts": ["pass-git-helper = passgithelper:main"]},
-    author="Johannes Wienke",
-    author_email="languitar@semipol.de",
-    url="https://github.com/languitar/pass-git-helper",
-    description="A git credential helper interfacing with pass, "
-    "the standard unix password manager.",
-    license="LGPLv3+",
-    keywords=["git", "passwords", "pass", "credentials", "password store"],
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Topic :: Utilities",
-        "License :: OSI Approved :: "
-        "GNU Lesser General Public License v3 or later (LGPLv3+)",
-    ],
-)
+setup()


### PR DESCRIPTION
This is very conservative option, which should work on all normal (and even less than normal) Python platforms. However, I found declarative syntax to be much more pleasing.