### PR TITLE
Add static username extractor, which reads username from mapping.

### DIFF
--- a/passgithelper.py
+++ b/passgithelper.py
@@ -306,6 +306,23 @@ class EntryNameExtractor(DataExtractor):
         return os.path.split(entry_name)[1]
 
 
+class StaticUsernameExtractor:
+    """Extract username from a static field in the mapping configuration."""
+
+    def __init__(self) -> None:
+        self._username = None
+
+    def configure(self, config: configparser.SectionProxy) -> None:
+        """Store the username from the mapping configuration."""
+        self._username = config.get("username")
+
+    def get_value(
+        self, entry_name: Text, entry_lines: Sequence[Text]  # noqa: ARG002
+    ) -> Optional[Text]:
+        """Return the stored username."""
+        return self._username
+
+
 _line_extractor_name = "specific_line"
 _username_extractors = {
     _line_extractor_name: SpecificLineExtractor(1, 0, option_suffix="_username"),
@@ -313,6 +330,7 @@ _username_extractors = {
         r"^username: +(.*)$", option_suffix="_username"
     ),
     "entry_name": EntryNameExtractor(option_suffix="_username"),
+    "static": StaticUsernameExtractor(),
 }
 _password_extractors = {
     _line_extractor_name: SpecificLineExtractor(0, 0, option_suffix="_password"),

--- a/test_passgithelper.py
+++ b/test_passgithelper.py
@@ -137,6 +137,59 @@ class TestEntryNameExtractor:
         assert passgithelper.EntryNameExtractor().get_value("foo/bar", []) == "bar"
 
 
+class TestStaticUsernameExtractor:
+    def test_extracts_username_from_config(self) -> None:
+        config = configparser.ConfigParser()
+        config.read_string("""[test]
+username = address@example.com
+""")
+        
+        extractor = passgithelper.StaticUsernameExtractor()
+        extractor.configure(config["test"])
+        
+        assert extractor.get_value("any/entry", ["any", "lines"]) == "address@example.com"
+
+    def test_returns_none_when_no_username_configured(self) -> None:
+        config = configparser.ConfigParser()
+        config.read_string("""[test]
+target = some/target
+""")
+        
+        extractor = passgithelper.StaticUsernameExtractor()
+        extractor.configure(config["test"])
+        
+        assert extractor.get_value("any/entry", ["any", "lines"]) is None
+
+    def test_inherits_from_default_section(self) -> None:
+        config = configparser.ConfigParser()
+        config.read_string("""[DEFAULT]
+username = default@example.com
+
+[test]
+target = some/target
+""")
+        
+        extractor = passgithelper.StaticUsernameExtractor()
+        extractor.configure(config["test"])
+        
+        assert extractor.get_value("any/entry", ["any", "lines"]) == "default@example.com"
+
+    def test_section_overrides_default(self) -> None:
+        config = configparser.ConfigParser()
+        config.read_string("""[DEFAULT]
+username = default@example.com
+
+[test]
+target = some/target
+username = override@example.com
+""")
+        
+        extractor = passgithelper.StaticUsernameExtractor()
+        extractor.configure(config["test"])
+        
+        assert extractor.get_value("any/entry", ["any", "lines"]) == "override@example.com"
+
+
 @pytest.mark.parametrize(
     "helper_config",
     [


### PR DESCRIPTION
- Usernames don't need to live in pass, or typed every time
- Allows specifying usernames at DEFAULT and rule levels in git-pass-mapping.ini
- Added `StaticUsernameExtractor` that reads usernames directly from mapping configuration
- Added tests