### PR TITLE
build!: drop Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Clone repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [tool.ruff]
 src = ["src"]
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ keywords =
     credentials
     password store
 classifiers =
-    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.11
     Topic :: Utilities
     License :: OSI Approved ::
     GNU Lesser General Public License v3 or later (LGPLv3+)
@@ -22,6 +22,7 @@ project_urls =
 [options]
 install_requires =
     pyxdg
+python_requires = >=3.11
 py_modules =
     passgithelper
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,test-py{310,311,312,313}, check, coverage
+envlist = coverage-clean,test-py{311,312,313}, check, coverage
 
 [testenv]
 extras = test
@@ -18,7 +18,7 @@ commands = coverage erase
 depends =
 
 [testenv:coverage]
-depends = test-py{39,310,311,312,313}
+depends = test-py{311,312,313}
 deps =
     coverage
 skip_install = true
@@ -40,7 +40,6 @@ commands =
 
 [gh-actions]
 python =
-    3.10: py310, coverage
     3.11: py311, coverage
     3.12: py312, coverage
     3.13: py313, coverage


### PR DESCRIPTION
Drops official support for Python 3.10. Debian stable and the current Ubuntu LTS are at least on 3.11.

BREAKING CHANGE: Python 3.10 support has been dropped. 3.11 is the
    minimum version required now.